### PR TITLE
Fix video not autoplaying

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,22 +1,74 @@
 const DELAY_IN_MS = 3000;
 const VIDEO_LENGTH_IN_MS = 20000;
+const MAX_Z_INDEX = 2147483647;
 
-const VIDEO_HTML_STRING =
-  "<video autoplay loop style='height: 100vh; width: 100vw'><source src='https://raw.githubusercontent.com/Roystbeef/Cenafy/master/cena.webm' type='video/webm'><source src='https://raw.githubusercontent.com/Roystbeef/Cenafy/master/cena.mp4' type='video/mp4'></video>";
+const SHOULD_CENAFY = Math.floor(Math.random() * 100) === 69;
+
+let hasLearnedWhoTheChampIs = false;
+let timeoutId;
+
+function getCenafyVideo() {
+  const video = document.createElement("video");
+  video.src = chrome.runtime.getURL("cena.mp4");
+  Object.assign(video.style, {
+    position: "fixed",
+    background: "black",
+    zIndex: MAX_Z_INDEX,
+    height: "100vh",
+    width: "100vw",
+    inset: 0,
+  });
+
+  return video;
+}
 
 function cenafy() {
-  setTimeout(() => {
+  if (hasLearnedWhoTheChampIs) {
+    return;
+  }
+
+  // This acts as a basic debounce so that if the user is doing
+  // something click intensive, we don't show them who the champ is
+  // until they've taken a brief break
+  if (timeoutId != null) {
+    clearTimeout(timeoutId);
+  }
+
+  timeoutId = setTimeout(() => {
+    // Don't show the video if the tab isn't active. We'll show
+    // them who the champ is next time
+    if (document.hidden) {
+      return;
+    }
+
     const body = document.body;
-    body.innerHTML = VIDEO_HTML_STRING;
+    const previousPointerEvents = body.style.pointerEvents;
+    body.style.pointerEvents = "none";
+    const previousBackgroundColor = body.style.backgroundColor;
     body.style.backgroundColor = "black";
-    setTimeout(() => {
-      // Wait 20 seconds for cena to finish
-      window.location.replace(document.URL);
-    }, VIDEO_LENGTH_IN_MS);
+
+    const video = getCenafyVideo();
+    body.appendChild(video);
+
+    // Prevent future clicks from spawning additional videos while
+    // this is playing. In theory, pointer-events: none should guard
+    // against this but child nodes could have pointer-events set
+    // explicitly
+    window.removeEventListener("mouseup", cenafy);
+
+    video.addEventListener("ended", () => {
+      body.style.backgroundColor = previousBackgroundColor;
+      body.style.pointerEvents = previousPointerEvents;
+      body.removeChild(video);
+      hasLearnedWhoTheChampIs = true;
+    });
+
+    video.play();
   }, DELAY_IN_MS);
 }
 
-const chance = Math.floor(Math.random() * 100);
-if (chance === 69) {
-  cenafy();
+if (SHOULD_CENAFY) {
+  // Add this to mouse-up instead of on load so we can auto-play
+  // the video with sound
+  window.addEventListener("mouseup", cenafy);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,13 @@
     }
   ],
 
-  "permissions": ["http://*/*", "https://*/*"],
-  "manifest_version": 2
+  "web_accessible_resources": [
+    {
+      "resources": ["cena.mp4"],
+      "matches": ["http://*/*", "https://*/*"]
+    }
+  ],
+
+  "host_permissions": ["<all_urls>"],
+  "manifest_version": 3
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Cenafy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "And his name is John Cena",
 
   "content_scripts": [


### PR DESCRIPTION
## Overview
Huh, turns out the chrome store was right to remove the extension since it was no longer working a lot of the time. Around 2018, browsers rightfully made it so that videos can't autoplay w audio unless the user interacts w the page first (although there are a few exceptions to this depending on the heuristics for the website eg. youtube).

This PR updates the functionality to instead play the video after a user has clicked something on the page. The chance that this will happen is still determined at page load, so there's still a 1/100 chance that a page will be cenafied (although in practice it's slightly lower since a user may not click on the page at all)

A few other fixes in this PR:
- Updated the manifest to v3
- Updated the video url to read from the extension directly instead of pointing to the video via github. A few pros to this:
  - If this repo were to somehow be compromised, a malicious agent could change the video, and users who have the extension installed would be pointed to that instead
  - Loading the video from a local file makes it so the video works with sites with a strict content-security-policy since we're no longer loading resources from a separate origin for the extension
- Before, we were reloading the page after the video finished playing. This isn't great if a user is in the middle of entering a form, etc. (and probably even worse if playing the video is tied to click events which could happen way later than before). So instead, we just render the video on top of all the elements and remove it once the video completes. Yeah idk why I didn't fix this sooner in hindsight

## Validation
- See that the video now plays with audio as expected (although now only after the user has interacted with the document)
- See that clicking multiple times doesn't create multiple videos
- See that the video loads on various sites
- See that the website works as expected after the video has finished